### PR TITLE
Implement league navigation flow

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,63 +2,18 @@ import { Drawer } from 'expo-router/drawer';
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable } from 'react-native';
 import { useRouter } from 'expo-router';
+import { AuthProvider } from '../context/AuthContext';
 
 export default function Layout() {
   const router = useRouter();
 
   return (
-    <Drawer>
-      <Drawer.Screen
-        name="index"
-        options={{ drawerLabel: 'Inicio' }}
-      />
-      <Drawer.Screen
-        name="public/contacto"
-        options={{ drawerLabel: 'Contacto' }}
-      />
-      <Drawer.Screen
-        name="public/facebook"
-        options={{ drawerLabel: 'Facebook' }}
-      />
-      <Drawer.Screen
-        name="public/youtube"
-        options={{ drawerLabel: 'YouTube' }}
-      />
-      <Drawer.Screen
-        name="public/terminos"
-        options={{ drawerLabel: 'Términos y Condiciones' }}
-      />
-      <Drawer.Screen
-        name="public/politicas"
-        options={{ drawerLabel: 'Políticas de Uso' }}
-      />
-      <Drawer.Screen
-        name="public/ligas/index"
-        options={{ drawerLabel: 'Ligas' }}
-      />
-      <Drawer.Screen
-        name="auth/login"
-        options={{ drawerLabel: 'Iniciar Sesión' }}
-      />
-      <Drawer.Screen
-        name="auth/registro"
-        options={{ drawerLabel: 'Registrarse' }}
-      />
-      <Drawer.Screen
-        name="admin/crear-liga"
-        options={{ drawerLabel: 'Crear Liga' }}
-      />
-      <Drawer.Screen
-        name="perfil"
-        options={{
-          drawerLabel: 'Perfil',
-          headerRight: () => (
-            <Pressable onPress={() => router.push('/perfil')} style={{ marginRight: 15 }}>
-              <Ionicons name="person-circle-outline" size={26} color="#000" />
-            </Pressable>
-          ),
-        }}
-      />
-    </Drawer>
+    <AuthProvider>
+      <Drawer>
+        <Drawer.Screen name="index" options={{ drawerLabel: 'Inicio' }} />
+        <Drawer.Screen name="public/ligas/index" options={{ drawerLabel: 'Ligas' }} />
+      </Drawer>
+    </AuthProvider>
   );
 }
+

--- a/app/public/ligas/[ligaId]/categorias/[categoriaId]/equipos/[equipoId]/info.tsx
+++ b/app/public/ligas/[ligaId]/categorias/[categoriaId]/equipos/[equipoId]/info.tsx
@@ -1,0 +1,56 @@
+import React, { useContext } from 'react';
+import { View, Text, StyleSheet, Pressable, Alert } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useLocalSearchParams } from 'expo-router';
+import { AuthContext } from '../../../../../../../context/AuthContext';
+
+export default function EquipoInfoScreen() {
+  const { equipoId } = useLocalSearchParams<{ equipoId: string }>();
+  const { estaAutenticado } = useContext(AuthContext);
+
+  const manejarNotificacion = () => {
+    if (!estaAutenticado) {
+      Alert.alert('Inicia sesión para activar notificaciones');
+      return;
+    }
+    Alert.alert('Notificaciones activadas');
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.titulo}>Acerca del equipo</Text>
+      <Text style={styles.texto}>ID: {equipoId}</Text>
+      <Pressable onPress={manejarNotificacion} style={styles.notificacion}>
+        <Ionicons name="notifications-outline" size={24} color="#fff" />
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: '#fff',
+  },
+  titulo: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: '#1E90FF',
+    marginBottom: 10,
+  },
+  texto: {
+    fontSize: 16,
+    marginBottom: 10,
+  },
+  notificacion: {
+    backgroundColor: '#1E90FF',
+    padding: 10,
+    borderRadius: 25,
+    alignSelf: 'flex-start',
+  },
+});
+
+export const screenOptions = {
+  title: 'Acerca del equipo',
+};

--- a/app/public/ligas/[ligaId]/categorias/[categoriaId]/equipos/index.tsx
+++ b/app/public/ligas/[ligaId]/categorias/[categoriaId]/equipos/index.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState, useContext } from 'react';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import { getEquipos, Equipo } from '../../../../../../services/equipoService';
+import { AuthContext } from '../../../../../../context/AuthContext';
+
+export default function EquiposScreen() {
+  const { categoriaId, ligaId } = useLocalSearchParams<{ categoriaId: string; ligaId: string }>();
+  const [equipos, setEquipos] = useState<Equipo[]>([]);
+  const router = useRouter();
+  const { estaAutenticado } = useContext(AuthContext);
+
+  useEffect(() => {
+    async function fetchEquipos() {
+      try {
+        if (categoriaId) {
+          const data = await getEquipos(String(categoriaId));
+          setEquipos(data);
+        }
+      } catch (error) {
+        console.error('Error cargando equipos:', error);
+      }
+    }
+    fetchEquipos();
+  }, [categoriaId]);
+
+  const irDetalle = (id: string) => {
+    router.push(`/public/ligas/${ligaId}/categorias/${categoriaId}/equipos/${id}`);
+  };
+
+  const renderEquipo = ({ item }: { item: Equipo }) => (
+    <TouchableOpacity style={styles.card} onPress={() => irDetalle(item.id)}>
+      <View style={styles.cardFooter}>
+        <Text style={styles.nombre}>{item.nombre}</Text>
+        <Pressable
+          onPress={() => irDetalle(item.id)}
+        >
+          <Ionicons name="information-circle-outline" size={20} color="#1E90FF" />
+        </Pressable>
+      </View>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={equipos}
+        keyExtractor={(item) => item.id}
+        renderItem={renderEquipo}
+        contentContainerStyle={styles.lista}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    padding: 15,
+  },
+  lista: {
+    gap: 15,
+  },
+  card: {
+    backgroundColor: '#f9f9f9',
+    borderRadius: 15,
+    padding: 15,
+    alignItems: 'center',
+    elevation: 3,
+  },
+  cardFooter: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  nombre: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: '#1E90FF',
+  },
+});
+
+export const screenOptions = {
+  title: 'Equipos',
+};

--- a/app/public/ligas/[ligaId]/categorias/[categoriaId]/info.tsx
+++ b/app/public/ligas/[ligaId]/categorias/[categoriaId]/info.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+
+export default function CategoriaInfoScreen() {
+  const { categoriaId } = useLocalSearchParams<{ categoriaId: string }>();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.titulo}>Información de la categoría</Text>
+      <Text style={styles.texto}>ID: {categoriaId}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: '#fff',
+  },
+  titulo: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: '#1E90FF',
+    marginBottom: 10,
+  },
+  texto: {
+    fontSize: 16,
+  },
+});
+
+export const screenOptions = {
+  title: 'Acerca de la categoría',
+};

--- a/app/public/ligas/[ligaId]/categorias/index.tsx
+++ b/app/public/ligas/[ligaId]/categorias/index.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import { getCategorias, Categoria } from '../../../../../services/categoriaService';
+
+export default function CategoriasScreen() {
+  const { ligaId } = useLocalSearchParams<{ ligaId: string }>();
+  const [categorias, setCategorias] = useState<Categoria[]>([]);
+  const router = useRouter();
+
+  useEffect(() => {
+    async function fetchCategorias() {
+      try {
+        if (ligaId) {
+          const data = await getCategorias(String(ligaId));
+          setCategorias(data);
+        }
+      } catch (error) {
+        console.error('Error cargando categorías:', error);
+      }
+    }
+    fetchCategorias();
+  }, [ligaId]);
+
+  const renderCategoria = ({ item }: { item: Categoria }) => (
+    <TouchableOpacity
+      style={styles.card}
+      onPress={() =>
+        router.push(`/public/ligas/${ligaId}/categorias/${item.id}/equipos`)
+      }
+    >
+      <View style={styles.cardFooter}>
+        <Text style={styles.nombre}>{item.nombre}</Text>
+        <Pressable
+          onPress={() =>
+            router.push(`/public/ligas/${ligaId}/categorias/${item.id}/info`)
+          }
+        >
+          <Ionicons name="information-circle-outline" size={20} color="#1E90FF" />
+        </Pressable>
+      </View>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={categorias}
+        keyExtractor={(item) => item.id}
+        renderItem={renderCategoria}
+        contentContainerStyle={styles.lista}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    padding: 15,
+  },
+  lista: {
+    gap: 15,
+  },
+  card: {
+    backgroundColor: '#f9f9f9',
+    borderRadius: 15,
+    padding: 15,
+    alignItems: 'center',
+    elevation: 3,
+  },
+  cardFooter: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  nombre: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: '#1E90FF',
+  },
+});
+
+export const screenOptions = {
+  title: 'Categorías',
+};

--- a/app/public/ligas/[ligaId]/info.tsx
+++ b/app/public/ligas/[ligaId]/info.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import { getLiga, LigaDetalle } from '../../../../services/ligaService';
+
+export default function LigaInfoScreen() {
+  const { ligaId } = useLocalSearchParams<{ ligaId: string }>();
+  const [liga, setLiga] = useState<LigaDetalle | null>(null);
+  const [cargando, setCargando] = useState(true);
+
+  useEffect(() => {
+    async function fetchLiga() {
+      try {
+        if (ligaId) {
+          const data = await getLiga(String(ligaId));
+          setLiga(data);
+        }
+      } finally {
+        setCargando(false);
+      }
+    }
+    fetchLiga();
+  }, [ligaId]);
+
+  if (cargando) {
+    return (
+      <View style={styles.container}> 
+        <ActivityIndicator size="large" color="#1E90FF" />
+      </View>
+    );
+  }
+
+  if (!liga) {
+    return (
+      <View style={styles.container}> 
+        <Text>No se encontró la liga.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.titulo}>{liga.nombre}</Text>
+      {liga.descripcion && <Text style={styles.texto}>{liga.descripcion}</Text>}
+      {liga.fechaCreacion && (
+        <Text style={styles.texto}>Creada: {new Date(liga.fechaCreacion).toLocaleDateString()}</Text>
+      )}
+      {liga.creadores && liga.creadores.length > 0 && (
+        <Text style={styles.texto}>Creadores: {liga.creadores.join(', ')}</Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: '#fff',
+  },
+  titulo: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: '#1E90FF',
+    marginBottom: 10,
+  },
+  texto: {
+    fontSize: 16,
+    marginBottom: 8,
+  },
+});
+
+export const screenOptions = {
+  title: 'Información de la liga',
+};

--- a/app/public/ligas/index.tsx
+++ b/app/public/ligas/index.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, TextInput, FlatList, TouchableOpacity, Image } from 'react-native';
+import { View, Text, StyleSheet, TextInput, FlatList, TouchableOpacity, Image, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { getLigas } from '../../../services/ligaService'; // Asegúrate de tener este servicio
+import { useRouter } from 'expo-router';
+import { getLigas } from '../../../services/ligaService';
 
 interface Liga {
   id: string;
@@ -12,6 +13,7 @@ interface Liga {
 export default function LigasScreen() {
   const [ligas, setLigas] = useState<Liga[]>([]);
   const [busqueda, setBusqueda] = useState('');
+  const router = useRouter();
 
   useEffect(() => {
     async function fetchLigas() {
@@ -30,13 +32,21 @@ export default function LigasScreen() {
   );
 
   const renderLiga = ({ item }: { item: Liga }) => (
-    <TouchableOpacity style={styles.card}>
+    <TouchableOpacity
+      style={styles.card}
+      onPress={() => router.push(`/public/ligas/${item.id}/categorias`)}
+    >
       {item.imagen ? (
         <Image source={{ uri: item.imagen }} style={styles.imagen} />
       ) : (
         <View style={styles.imagenPlaceholder} />
       )}
-      <Text style={styles.nombreLiga}>{item.nombre}</Text>
+      <View style={styles.cardFooter}>
+        <Text style={styles.nombreLiga}>{item.nombre}</Text>
+        <Pressable onPress={() => router.push(`/public/ligas/${item.id}/info`)}>
+          <Ionicons name="information-circle-outline" size={20} color="#1E90FF" />
+        </Pressable>
+      </View>
     </TouchableOpacity>
   );
 
@@ -92,6 +102,12 @@ const styles = StyleSheet.create({
     padding: 15,
     alignItems: 'center',
     elevation: 3,
+  },
+  cardFooter: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
   },
   imagen: {
     width: '100%',

--- a/services/categoriaService.tsx
+++ b/services/categoriaService.tsx
@@ -1,0 +1,21 @@
+import api from '../api';
+
+export interface Categoria {
+  id: string;
+  nombre: string;
+  descripcion?: string;
+}
+
+export const getCategorias = async (ligaId: string): Promise<Categoria[]> => {
+  try {
+    const res = await api.get(`/ligas/${ligaId}/categorias`);
+    return res.data.map((cat: any) => ({
+      id: cat._id,
+      nombre: cat.nombre,
+      descripcion: cat.descripcion || '',
+    }));
+  } catch (error) {
+    console.error('Error al obtener categorías:', error);
+    throw error;
+  }
+};

--- a/services/equipoService.tsx
+++ b/services/equipoService.tsx
@@ -1,0 +1,21 @@
+import api from '../api';
+
+export interface Equipo {
+  id: string;
+  nombre: string;
+  representantes?: string[];
+}
+
+export const getEquipos = async (categoriaId: string): Promise<Equipo[]> => {
+  try {
+    const res = await api.get(`/categorias/${categoriaId}/equipos`);
+    return res.data.map((eq: any) => ({
+      id: eq._id,
+      nombre: eq.nombre,
+      representantes: eq.representantes || [],
+    }));
+  } catch (error) {
+    console.error('Error al obtener equipos:', error);
+    throw error;
+  }
+};

--- a/services/ligaService.tsx
+++ b/services/ligaService.tsx
@@ -6,6 +6,12 @@ export interface Liga {
   imagen?: string;
 }
 
+export interface LigaDetalle extends Liga {
+  descripcion?: string;
+  fechaCreacion?: string;
+  creadores?: string[];
+}
+
 export const getLigas = async (): Promise<Liga[]> => {
   try {
     const res = await api.get('/ligas');
@@ -17,6 +23,24 @@ export const getLigas = async (): Promise<Liga[]> => {
     }));
   } catch (error) {
     console.error('Error al obtener ligas:', error);
+    throw error;
+  }
+};
+
+export const getLiga = async (id: string): Promise<LigaDetalle> => {
+  try {
+    const res = await api.get(`/ligas/${id}`);
+    const liga = res.data;
+    return {
+      id: liga._id,
+      nombre: liga.nombre,
+      imagen: liga.imagen || '',
+      descripcion: liga.descripcion || '',
+      fechaCreacion: liga.fechaCreacion || liga.createdAt || '',
+      creadores: liga.creadores || (liga.creador ? [liga.creador] : []),
+    };
+  } catch (error) {
+    console.error('Error al obtener liga:', error);
     throw error;
   }
 };


### PR DESCRIPTION
## Summary
- simplify drawer menu to only show Inicio and Ligas
- wrap app in `AuthProvider`
- update liga list UI with cards that link to categories
- add league detail screen with API integration
- add category and team screens
- add services for categories and teams

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868e56aff108333a166003fadd76e80